### PR TITLE
Re-enable the slow test in CI

### DIFF
--- a/tests/ProjectEuler.Tests/Puzzles/Puzzle005Tests.cs
+++ b/tests/ProjectEuler.Tests/Puzzles/Puzzle005Tests.cs
@@ -24,7 +24,7 @@ namespace MartinCostello.ProjectEuler.Puzzles
             Puzzles.AssertSolution<Puzzle005>(args, expected);
         }
 
-        [NotCITheory]
+        [Theory]
         [InlineData("20", 232792560)]
         public static void Puzzle005_Returns_Correct_Solution_Slow(string max, int expected)
         {


### PR DESCRIPTION
Re-enable the test that was slow in CI before the .NET Core migration.