### PR TITLE
Update to .NET Core 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,17 @@ dist: trusty
 
 env:
   global:
-    - CLI_VERSION=1.0.1
+    - CLI_VERSION=2.0.0-preview1-005977
     - DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
     - NUGET_XMLDOC_MODE=skip
 
 branches:
   only:
     - master
+
+cache:
+  directories:
+    - /home/travis/.nuget/packages
 
 addons:
   apt:
@@ -20,11 +24,5 @@ addons:
     - libssl-dev
     - libunwind8
 
-install:
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
-  - dotnet --info
-
 script:
-  - ./build.sh
+  - ./build.sh --restore-packages

--- a/Build.ps1
+++ b/Build.ps1
@@ -1,38 +1,58 @@
 param(
-    [Parameter(Mandatory=$false)][bool]   $RestorePackages  = $false,
-    [Parameter(Mandatory=$false)][string] $Configuration    = "Release",
-    [Parameter(Mandatory=$false)][string] $VersionSuffix    = "",
-    [Parameter(Mandatory=$false)][string] $OutputPath       = "",
-    [Parameter(Mandatory=$false)][bool]   $PatchVersion     = $false,
-    [Parameter(Mandatory=$false)][bool]   $RunTests         = $true
+    [Parameter(Mandatory = $false)][switch] $RestorePackages,
+    [Parameter(Mandatory = $false)][string] $Configuration = "Release",
+    [Parameter(Mandatory = $false)][string] $VersionSuffix = "",
+    [Parameter(Mandatory = $false)][string] $OutputPath = "",
+    [Parameter(Mandatory = $false)][switch] $PatchVersion,
+    [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
 $ErrorActionPreference = "Stop"
 
-$solutionPath  = Split-Path $MyInvocation.MyCommand.Definition
-$framework     = "netcoreapp1.1"
-$dotnetVersion = "1.0.1"
+$solutionPath = Split-Path $MyInvocation.MyCommand.Definition
+$solutionFile = Join-Path $solutionPath "ProjectEuler.sln"
+$dotnetVersion = "2.0.0-preview1-005977"
 
 if ($OutputPath -eq "") {
-    $OutputPath = "$(Convert-Path "$PSScriptRoot")\artifacts"
+    $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
 }
 
-$env:DOTNET_INSTALL_DIR = "$(Convert-Path "$PSScriptRoot")\.dotnetcli"
-
-if ($env:CI -ne $null -Or $env:TF_BUILD -ne $null) {
+if ($env:CI -ne $null) {
     $RestorePackages = $true
     $PatchVersion = $true
 }
 
-if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
-    mkdir $env:DOTNET_INSTALL_DIR | Out-Null
+$installDotNetSdk = $false;
+
+if (((Get-Command "dotnet.exe" -ErrorAction SilentlyContinue) -eq $null) -and ((Get-Command "dotnet" -ErrorAction SilentlyContinue) -eq $null)) {
+    Write-Host "The .NET Core SDK is not installed."
+    $installDotNetSdk = $true
+}
+else {
+    $installedDotNetVersion = (dotnet --version | Out-String).Trim()
+    if ($installedDotNetVersion -ne $dotnetVersion) {
+        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion but $installedDotNetVersion was found."
+        $installDotNetSdk = $true
+    }
+}
+
+if ($installDotNetSdk -eq $true) {
+    $env:DOTNET_INSTALL_DIR = Join-Path "$(Convert-Path "$PSScriptRoot")" ".dotnetcli"
+
+    if (!(Test-Path $env:DOTNET_INSTALL_DIR)) {
+        mkdir $env:DOTNET_INSTALL_DIR | Out-Null
+    }
+
     $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
     Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
     & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
-}
 
-$env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
-$dotnet   = "$env:DOTNET_INSTALL_DIR\dotnet"
+    $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"
+    $dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet"
+}
+else {
+    $dotnet = "dotnet"
+}
 
 function DotNetRestore {
     param([string]$Project)
@@ -43,11 +63,12 @@ function DotNetRestore {
 }
 
 function DotNetBuild {
-    param([string]$Project, [string]$Configuration, [string]$VersionSuffix)
+    param([string]$Project)
     if ($VersionSuffix) {
-        & $dotnet build $Project --output $OutputPath --framework $framework --configuration $Configuration --version-suffix "$VersionSuffix"
-    } else {
-        & $dotnet build $Project --output $OutputPath --framework $framework --configuration $Configuration
+        & $dotnet build $Project --output $OutputPath --configuration $Configuration --version-suffix "$VersionSuffix"
+    }
+    else {
+        & $dotnet build $Project --output $OutputPath --configuration $Configuration
     }
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet build failed with exit code $LASTEXITCODE"
@@ -56,7 +77,7 @@ function DotNetBuild {
 
 function DotNetTest {
     param([string]$Project)
-    & $dotnet test $Project --output $OutputPath --framework $framework --no-build
+    & $dotnet test $Project --output $OutputPath --no-build
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
     }
@@ -64,9 +85,14 @@ function DotNetTest {
 
 if ($PatchVersion -eq $true) {
 
+    $gitBranch = $env:BUILD_SOURCEBRANCHNAME
+
+    if ([string]::IsNullOrEmpty($gitBranch)) {
+        $gitBranch = (git rev-parse --abbrev-ref HEAD | Out-String).Trim()
+    }
+
     $gitRevision = (git rev-parse HEAD | Out-String).Trim()
-    $gitBranch   = (git rev-parse --abbrev-ref HEAD | Out-String).Trim()
-    $timestamp   = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK")
+    $timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssK")
 
     $assemblyVersion = Get-Content ".\AssemblyVersion.cs" -Raw
     $assemblyVersionWithMetadata = "{0}using System.Reflection;`r`n`r`n[assembly: AssemblyMetadata(""CommitHash"", ""{1}"")]`r`n[assembly: AssemblyMetadata(""CommitBranch"", ""{2}"")]`r`n[assembly: AssemblyMetadata(""BuildTimestamp"", ""{3}"")]" -f $assemblyVersion, $gitRevision, $gitBranch, $timestamp
@@ -74,28 +100,22 @@ if ($PatchVersion -eq $true) {
     Set-Content ".\AssemblyVersion.cs" $assemblyVersionWithMetadata -Encoding utf8
 }
 
-$projects = @(
-    (Join-Path $solutionPath "src\ProjectEuler\ProjectEuler.csproj"),
-    (Join-Path $solutionPath "tests\ProjectEuler.Tests\ProjectEuler.Tests.csproj")
-)
+if ($RestorePackages -eq $true) {
+    Write-Host "Restoring NuGet packages for solution..." -ForegroundColor Green
+    DotNetRestore $solutionFile
+}
 
+# Will compile the main project by extension
 $testProjects = @(
     (Join-Path $solutionPath "tests\ProjectEuler.Tests\ProjectEuler.Tests.csproj")
 )
 
-if ($RestorePackages -eq $true) {
-    Write-Host "Restoring NuGet packages for $($projects.Count) projects..." -ForegroundColor Green
-    ForEach ($project in $projects) {
-        DotNetRestore $project
-    }
-}
-
-Write-Host "Building $($projects.Count) projects..." -ForegroundColor Green
-ForEach ($project in $projects) {
+Write-Host "Building $($testProjects.Count) projects..." -ForegroundColor Green
+ForEach ($project in $testProjects) {
     DotNetBuild $project $Configuration $PrereleaseSuffix
 }
 
-if ($RunTests -eq $true) {
+if ($SkipTests -eq $false) {
     Write-Host "Testing $($testProjects.Count) project(s)..." -ForegroundColor Green
     ForEach ($project in $testProjects) {
         DotNetTest $project

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "ProjectEuler.sln"
-$dotnetVersion = "2.0.0-preview2-006497"
+$dotnetVersion = "2.0.0"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"

--- a/Build.ps1
+++ b/Build.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = "Stop"
 
 $solutionPath = Split-Path $MyInvocation.MyCommand.Definition
 $solutionFile = Join-Path $solutionPath "ProjectEuler.sln"
-$dotnetVersion = "2.0.0-preview1-005977"
+$dotnetVersion = "2.0.0-preview2-006497"
 
 if ($OutputPath -eq "") {
     $OutputPath = Join-Path "$(Convert-Path "$PSScriptRoot")" "artifacts"
@@ -44,7 +44,7 @@ if ($installDotNetSdk -eq $true) {
     }
 
     $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
-    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
+    Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.ps1" -OutFile $installScript
     & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
 
     $env:PATH = "$env:DOTNET_INSTALL_DIR;$env:PATH"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
-﻿os: Visual Studio 2015
+﻿os: Visual Studio 2017
 version: 1.0.{build}
 
 environment:
-  CLI_VERSION: 1.0.1
+  CLI_VERSION: 2.0.0-preview1-005977
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   NUGET_XMLDOC_MODE: skip
 

--- a/build.sh
+++ b/build.sh
@@ -35,7 +35,7 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview2-006497"
+export CLI_VERSION="2.0.0"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 

--- a/build.sh
+++ b/build.sh
@@ -35,14 +35,14 @@ while :; do
     shift
 done
 
-export CLI_VERSION="2.0.0-preview1-005977"
+export CLI_VERSION="2.0.0-preview2-006497"
 export DOTNET_INSTALL_DIR="$root/.dotnetcli"
 export PATH="$DOTNET_INSTALL_DIR:$PATH"
 
 dotnet_version=$(dotnet --version)
 
 if [ "$dotnet_version" != "$CLI_VERSION" ]; then
-    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/release/2.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
 fi
 
 if [ $restorePackages == 1 ]; then

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,56 @@
-﻿#!/bin/sh
-export artifacts=$(dirname "$(readlink -f "$0")")/artifacts
-export configuration=Release
+﻿#!/usr/bin/env bash
 
-dotnet restore --verbosity minimal || exit 1
-dotnet build --output $artifacts --configuration $configuration || exit 1
-dotnet test tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj --output $artifacts --configuration $configuration || exit 1
+root=$(cd "$(dirname "$0")"; pwd -P)
+artifacts=$root/artifacts
+configuration=Release
+
+restorePackages=0
+skipTests=0
+
+while :; do
+    if [ $# -le 0 ]; then
+        break
+    fi
+
+    lowerI="$(echo $1 | awk '{print tolower($0)}')"
+    case $lowerI in
+        -\?|-h|--help)
+            echo "./build.sh [--restore-packages] [--skip-tests]"
+            exit 1
+            ;;
+
+        --restore-packages)
+            restorePackages=1
+            ;;
+
+        --skip-tests)
+            skipTests=1
+            ;;
+
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
+            ;;
+    esac
+
+    shift
+done
+
+export CLI_VERSION="2.0.0-preview1-005977"
+export DOTNET_INSTALL_DIR="$root/.dotnetcli"
+export PATH="$DOTNET_INSTALL_DIR:$PATH"
+
+dotnet_version=$(dotnet --version)
+
+if [ "$dotnet_version" != "$CLI_VERSION" ]; then
+    curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
+fi
+
+if [ $restorePackages == 1 ]; then
+    dotnet restore ./ProjectEuler.sln --verbosity minimal || exit 1
+fi
+
+dotnet build ./ProjectEuler.sln --output $artifacts --configuration $configuration || exit 1
+
+if [ $skipTests == 0 ]; then
+    dotnet test ./tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj --output $artifacts --configuration $configuration  --no-build || exit 1
+fi

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "1.0.1"
+    "version": "2.0.0-preview1-005977"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 ﻿{
   "sdk": {
-    "version": "2.0.0-preview1-005977"
+    "version": "2.0.0-preview2-006497"
   }
 }

--- a/src/ProjectEuler/ProjectEuler.csproj
+++ b/src/ProjectEuler/ProjectEuler.csproj
@@ -7,7 +7,7 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.ProjectEuler</RootNamespace>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />
@@ -15,7 +15,7 @@
     <EmbeddedResource Include="Puzzles\**\*.txt" Exclude="bin\**;obj\**;packages\**;@(EmbeddedResource)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NodaTime" Version="2.0.0-beta20170123" />
+    <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/ProjectEuler/ProjectEuler.csproj
+++ b/src/ProjectEuler/ProjectEuler.csproj
@@ -4,7 +4,6 @@
     <Description>Solutions for Project Euler.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RootNamespace>MartinCostello.ProjectEuler</RootNamespace>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
+++ b/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
@@ -2,7 +2,6 @@
   <Import Project="..\..\ProjectEuler.Common.props" />
   <PropertyGroup>
     <Description>Tests for ProjectEuler.</Description>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6</PackageTargetFallback>
     <RootNamespace>MartinCostello.ProjectEuler</RootNamespace>
     <Summary>Tests for ProjectEuler.</Summary>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
+++ b/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6</PackageTargetFallback>
     <RootNamespace>MartinCostello.ProjectEuler</RootNamespace>
     <Summary>Tests for ProjectEuler.</Summary>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\AssemblyVersion.cs;..\..\CommonAssemblyInfo.cs" />
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NodaTime" Version="2.0.0-beta20170123" />
-    <PackageReference Include="NodaTime.Testing" Version="2.0.0-beta20170123" />
+    <PackageReference Include="NodaTime" Version="2.0.2" />
+    <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
+++ b/tests/ProjectEuler.Tests/ProjectEuler.Tests.csproj
@@ -14,7 +14,7 @@
     <ProjectReference Include="..\..\src\ProjectEuler\ProjectEuler.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NodaTime" Version="2.0.2" />
     <PackageReference Include="NodaTime.Testing" Version="2.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.0" PrivateAssets="All" />


### PR DESCRIPTION
  1. Update to use .NET Core 2.0 (`preview1-005977`).
  1. Refactor `Build.ps1` to be more efficient and improve runtime installation.
  1. Refactor `build.sh` to be functionally equivalent to `Build.ps1`.
  1. Update to NodaTime `2.0.2`.
  1. Update Visual Studio 2017 in AppVeyor.
  1. Cache NuGet packages in Travis CI.