### PR TITLE
Improvements and .NET Core 3.0 prep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 dist: trusty
+language: csharp
+mono: none
 
 os:
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: csharp
 mono: none
 

--- a/Build.ps1
+++ b/Build.ps1
@@ -28,7 +28,7 @@ if (($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue)) -and ($
 }
 else {
     Try {
-        $installedDotNetVersion = (dotnet --version 2>&1 | Out-String).Trim()
+        $installedDotNetVersion = (dotnet.exe --version 2>&1 | Out-String).Trim()
     }
     Catch {
         $installedDotNetVersion = "?"
@@ -49,6 +49,7 @@ if ($installDotNetSdk -eq $true) {
             mkdir $env:DOTNET_INSTALL_DIR | Out-Null
         }
         $installScript = Join-Path $env:DOTNET_INSTALL_DIR "install.ps1"
+        [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor "Tls12"
         Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
         & $installScript -Version "$dotnetVersion" -InstallDir "$env:DOTNET_INSTALL_DIR" -NoPath
     }
@@ -57,7 +58,7 @@ if ($installDotNetSdk -eq $true) {
     $dotnet = Join-Path "$env:DOTNET_INSTALL_DIR" "dotnet.exe"
 }
 else {
-    $dotnet = "dotnet"
+    $dotnet = "dotnet.exe"
 }
 
 Write-Host "Building solution..." -ForegroundColor Green

--- a/src/ProjectEuler/Puzzles/Puzzle039.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle039.cs
@@ -5,10 +5,8 @@ namespace MartinCostello.ProjectEuler.Puzzles
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
-    using System.Text;
 
     /// <summary>
     /// A class representing the solution to <c>https://projecteuler.net/problem=39</c>. This class cannot be inherited.
@@ -40,7 +38,13 @@ namespace MartinCostello.ProjectEuler.Puzzles
 
                     if (a + b + c == perimeter)
                     {
-                        string solution = $"{{{string.Join(",", new[] { a, b, c }.OrderBy((p) => p))}}}";
+                        // https://devblogs.microsoft.com/dotnet/floating-point-parsing-and-formatting-improvements-in-net-core-3-0/
+                        var sides = new[] { a, b, c }
+                            .OrderBy((p) => p)
+                            .Select((p) => p.ToString("G15", CultureInfo.InvariantCulture))
+                            .ToArray();
+
+                        string solution = "{" + string.Join(",", sides) + "}";
 
                         if (!solutions.Contains(solution))
                         {


### PR DESCRIPTION
  * Use a C# build image for Travis CI.
  * Use xenial in Travis CI instead of trusty.
  * Ensure TLS 1.2 is enabled.
  * Use `dotnet.exe` instead of `dotnet`.
  * Update `ToString()` for floating point numbers so it still works in .NET Core 3.0.