### PR TITLE
Add CPU Profiling

### DIFF
--- a/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
+++ b/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
@@ -6,6 +6,8 @@
     <RootNamespace>MartinCostello.ProjectEuler.Benchmarks</RootNamespace>
     <Summary>Benchmarks for ProjectEuler.</Summary>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!-- Workaround for https://github.com/dotnet/BenchmarkDotNet/pull/1420 -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ProjectEuler\ProjectEuler.csproj" />

--- a/tests/ProjectEuler.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/ProjectEuler.Benchmarks/PuzzleBenchmarks.cs
@@ -6,8 +6,10 @@ namespace MartinCostello.ProjectEuler.Benchmarks
     using System;
     using System.Collections.Generic;
     using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Diagnosers;
     using MartinCostello.ProjectEuler.Puzzles;
 
+    [EventPipeProfiler(EventPipeProfile.CpuSampling)]
     [MemoryDiagnoser]
     public class PuzzleBenchmarks
     {


### PR DESCRIPTION
  * Add a CPU profiler to the benchmarks.
  * Workaround bug in BenchmarkDotNet 0.12.1.
