### PR TITLE
Fix concurrent access to cache

### DIFF
--- a/src/ProjectEuler/Puzzles/Puzzle021.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle021.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
+
 namespace MartinCostello.ProjectEuler.Puzzles;
 
 /// <summary>
@@ -11,7 +13,7 @@ public sealed class Puzzle021 : Puzzle
     /// <summary>
     /// A cache of the result of invocations of <see cref="D(long)"/>. This field is read-only.
     /// </summary>
-    private static readonly Dictionary<long, long> _cache = new();
+    private static readonly ConcurrentDictionary<long, long> _cache = new();
 
     /// <inheritdoc />
     public override string Question => "Evaluate the sum of all the amicable numbers under 10,000.";
@@ -55,12 +57,5 @@ public sealed class Puzzle021 : Puzzle
     /// The sum of the proper divisors of <paramref name="value"/>.
     /// </returns>
     private static long D(long value)
-    {
-        if (_cache.TryGetValue(value, out long result))
-        {
-            return result;
-        }
-
-        return _cache[value] = Maths.GetProperDivisors(value).Sum();
-    }
+        => _cache.GetOrAdd(value, (p) => Maths.GetProperDivisors(p).Sum());
 }


### PR DESCRIPTION
Fix [`InvalidOperationException`](https://github.com/martincostello/project-euler/runs/8106198382?check_suite_focus=true#step:4:98) if two tests for puzzle 21 run in parallel with each other.
