### PR TITLE
Remove redundant suppressions

### DIFF
--- a/src/ProjectEuler/Program.cs
+++ b/src/ProjectEuler/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.Diagnostics;
 using MartinCostello.ProjectEuler;
 

--- a/tests/ProjectEuler.Benchmarks/Program.cs
+++ b/tests/ProjectEuler.Benchmarks/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2015. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using BenchmarkDotNet.Running;
 using MartinCostello.ProjectEuler.Benchmarks;
 


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
