### PR TITLE
Enable CI for dotnet-vnext

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,12 @@ name: build
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
   pull_request:
-    branches: [ main ]
+    branches: [ main, dotnet-vnext ]
   workflow_dispatch:
 
 jobs:
@@ -22,7 +26,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Setup .NET Core SDK
+    - name: Setup .NET SDK
       uses: actions/setup-dotnet@v3
 
     - name: Build, Test and Publish

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,7 +2,7 @@ name: dependency-review
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dotnet-vnext ]
 
 permissions:
   contents: read

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -15,7 +15,7 @@ $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.vers
 $installDotNetSdk = $false;
 
 if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
-    Write-Host "The .NET Core SDK is not installed."
+    Write-Host "The .NET SDK is not installed."
     $installDotNetSdk = $true
 }
 else {
@@ -27,7 +27,7 @@ else {
     }
 
     if ($installedDotNetVersion -ne $dotnetVersion) {
-        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion."
+        Write-Host "The required version of the .NET SDK is not installed. Expected $dotnetVersion."
         $installDotNetSdk = $true
     }
 }

--- a/build.ps1
+++ b/build.ps1
@@ -29,7 +29,7 @@ if ($OutputPath -eq "") {
 $installDotNetSdk = $false;
 
 if (($null -eq (Get-Command "dotnet" -ErrorAction SilentlyContinue)) -and ($null -eq (Get-Command "dotnet.exe" -ErrorAction SilentlyContinue))) {
-    Write-Host "The .NET Core SDK is not installed."
+    Write-Host "The .NET SDK is not installed."
     $installDotNetSdk = $true
 }
 else {
@@ -41,7 +41,7 @@ else {
     }
 
     if ($installedDotNetVersion -ne $dotnetVersion) {
-        Write-Host "The required version of the .NET Core SDK is not installed. Expected $dotnetVersion."
+        Write-Host "The required version of the .NET SDK is not installed. Expected $dotnetVersion."
         $installDotNetSdk = $true
     }
 }


### PR DESCRIPTION
- Also run CI builds for the `dotnet-vnext` branch.
- Skip CI for trivial changes.
- Update ".NET Core" to ".NET".