### PR TITLE
Refactoring

### DIFF
--- a/src/ProjectEuler/Puzzles/MaximumPathPuzzle.cs
+++ b/src/ProjectEuler/Puzzles/MaximumPathPuzzle.cs
@@ -21,7 +21,7 @@ public abstract class MaximumPathPuzzle : Puzzle
     internal static int ComputeMaximumPathSum(int[][] triangle)
     {
         var working = triangle
-            .Select((p) => p as IList<int>)
+            .Select((p) => p.ToList())
             .ToList();
 
         // Work through the triangle from the bottom up until there is one number left

--- a/src/ProjectEuler/Puzzles/Puzzle027.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle027.cs
@@ -72,7 +72,7 @@ public sealed class Puzzle027 : Puzzle
     /// <summary>
     /// Returns the result of the quadratic value for the specified values.
     /// </summary>
-    /// <param name="n">The value to use for the forumula.</param>
+    /// <param name="n">The value to use for the formula.</param>
     /// <param name="a">The value of the coefficient 'a'.</param>
     /// <param name="b">The value of the coefficient 'b'.</param>
     /// <returns>

--- a/src/ProjectEuler/Puzzles/Puzzle031.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle031.cs
@@ -29,7 +29,7 @@ public sealed class Puzzle031 : Puzzle
         }
 
         // Array containing the number of ways there are to
-        // make 1p up to the target using the avaiable coins.
+        // make 1p up to the target using the available coins.
         int[] ways = new int[target + 1];
 
         // There is one way to make 1p

--- a/src/ProjectEuler/Puzzles/Puzzle043.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle043.cs
@@ -12,14 +12,14 @@ public sealed class Puzzle043 : Puzzle
     /// An array containing the indexes and divisors to search the digit
     /// groups of in the 0-9 pandigital numbers. This field is read-only.
     /// </summary>
-    private static readonly Tuple<int, int>[] _ranges =
+    private static readonly (int Index, int Divisor)[] _ranges =
     {
-        Tuple.Create(3 - 1, 3),
-        Tuple.Create(4 - 1, 5),
-        Tuple.Create(5 - 1, 7),
-        Tuple.Create(6 - 1, 11),
-        Tuple.Create(7 - 1, 13),
-        Tuple.Create(8 - 1, 17),
+        (3 - 1, 3),
+        (4 - 1, 5),
+        (5 - 1, 7),
+        (6 - 1, 11),
+        (7 - 1, 13),
+        (8 - 1, 17),
     };
 
     /// <inheritdoc />
@@ -44,7 +44,7 @@ public sealed class Puzzle043 : Puzzle
 
         bool hasProperty = true;
 
-        foreach (var (start, divisor) in _ranges)
+        foreach ((int start, int divisor) in _ranges)
         {
             int end = start + 3;
 

--- a/src/ProjectEuler/Puzzles/Puzzle054.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle054.cs
@@ -23,8 +23,8 @@ public sealed class Puzzle054 : Puzzle
         string[] player1 = cards[..5];
         string[] player2 = cards[5..];
 
-        player1 = player1.OrderBy((p) => GetCardValue(p)).ToArray();
-        player2 = player2.OrderBy((p) => GetCardValue(p)).ToArray();
+        player1 = player1.OrderBy(GetCardValue).ToArray();
+        player2 = player2.OrderBy(GetCardValue).ToArray();
 
         var predicates = new IsHandPredicate[]
         {


### PR DESCRIPTION
- Fix two small typos.
- Convert an array to a list, rather than treat it as a list.
- Use named tuple instead of having an actual `Tuple`.
- Simplify `OrderBy()` usage.
