### PR TITLE
Use ReadOnlySpan<T>

### DIFF
--- a/src/ProjectEuler/Puzzles/Puzzle031.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle031.cs
@@ -8,16 +8,16 @@ namespace MartinCostello.ProjectEuler.Puzzles;
 /// </summary>
 public sealed class Puzzle031 : Puzzle
 {
-    /// <summary>
-    /// The coins, in pence, available in GBP. This field is read-only.
-    /// </summary>
-    private static readonly int[] Coins = [1, 2, 5, 10, 20, 50, 100, 200];
-
     /// <inheritdoc />
     public override string Question => "How many different ways can the specified amount of money, in pence, be made using any number of coins?";
 
     /// <inheritdoc />
     protected override int MinimumArguments => 1;
+
+    /// <summary>
+    /// Gets the coins, in pence, available in GBP.
+    /// </summary>
+    private static Span<int> Coins => new int[] { 1, 2, 5, 10, 20, 50, 100, 200 };
 
     /// <inheritdoc />
     protected override int SolveCore(string[] args)

--- a/src/ProjectEuler/Puzzles/Puzzle054.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle054.cs
@@ -8,13 +8,14 @@ namespace MartinCostello.ProjectEuler.Puzzles;
 /// </summary>
 public sealed class Puzzle054 : Puzzle
 {
-    private static readonly char[] Suits = ['C', 'D', 'H', 'S'];
-    private static readonly char[] Values = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
-
     private delegate bool IsHandPredicate(string[] cards, out char highCard);
 
     /// <inheritdoc />
     public override string Question => "How many hands does Player 1 win?";
+
+    private static ReadOnlySpan<char> Suits => new char[] { 'C', 'D', 'H', 'S' };
+
+    private static ReadOnlySpan<char> Values => new char[] { 'A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2' };
 
     internal static bool IsFirstPlayerTheWinner(string hand)
     {
@@ -185,8 +186,13 @@ public sealed class Puzzle054 : Puzzle
             return false;
         }
 
-        foreach (char value in Values.Except(new[] { threeValue }))
+        foreach (char value in Values)
         {
+            if (value == threeValue)
+            {
+                continue;
+            }
+
             if (IsPair(hand, value, out _))
             {
                 highCard = threeValue;
@@ -236,8 +242,13 @@ public sealed class Puzzle054 : Puzzle
             return false;
         }
 
-        foreach (char value in Values.Except(new[] { firstPairValue }))
+        foreach (char value in Values)
         {
+            if (value == firstPairValue)
+            {
+                continue;
+            }
+
             if (IsPair(hand, value, out char secondPairValue))
             {
                 highCard = firstPairValue > secondPairValue ? firstPairValue : secondPairValue;


### PR DESCRIPTION
- Use `ReadOnlySpan<T>` for arrays so they get more efficient access.
- Remove calls to `Except()` that allocate an array.
