### PR TITLE
Publish as native AoT

### DIFF
--- a/src/ProjectEuler/ProjectEuler.csproj
+++ b/src/ProjectEuler/ProjectEuler.csproj
@@ -2,12 +2,17 @@
   <PropertyGroup>
     <Description>Solutions for Project Euler.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OptimizationPreference>Speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+    <PublishAot>true</PublishAot>
     <RootNamespace>MartinCostello.ProjectEuler</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="Puzzles\**\*.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <TrimmerRootAssembly Include="ProjectEuler" />
   </ItemGroup>
 </Project>

--- a/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
+++ b/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
@@ -5,7 +5,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.ProjectEuler.Benchmarks</RootNamespace>
     <Summary>Benchmarks for ProjectEuler.</Summary>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ProjectEuler\ProjectEuler.csproj" />


### PR DESCRIPTION
- Publish the application with native AoT.
- Improve the timing resolution.
- Use `TimeProvider`.
- Use `TargetFramework` instead of `TargetFrameworks`.
