### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -1,9 +1,7 @@
 #! /usr/bin/env pwsh
 param(
-    [Parameter(Mandatory = $false)][string] $Framework = "net8.0"
 )
 
-$Configuration = "Release"
 $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
@@ -73,4 +71,4 @@ $benchmarks = (Join-Path $solutionPath "tests" "ProjectEuler.Benchmarks" "Projec
 
 Write-Host "Running benchmarks..." -ForegroundColor Green
 
-& $dotnet run --project $benchmarks --configuration $Configuration --framework $Framework
+& $dotnet run --project $benchmarks --configuration "Release" -- --filter '*'

--- a/tests/ProjectEuler.Benchmarks/CustomBenchmarkConfig.cs
+++ b/tests/ProjectEuler.Benchmarks/CustomBenchmarkConfig.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Martin Costello, 2015. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+
+namespace MartinCostello.ProjectEuler.Benchmarks;
+
+public class CustomBenchmarkConfig : ManualConfig
+{
+    public CustomBenchmarkConfig()
+        : base()
+    {
+        var job = Job.Default
+            .WithId("ProjectEuler")
+            .WithArguments([new MsBuildArgument("/p:UseArtifactsOutput=false")]);
+
+        AddJob(job);
+        AddDiagnoser(MemoryDiagnoser.Default);
+        AddDiagnoser(new EventPipeProfiler(EventPipeProfile.CpuSampling));
+    }
+}

--- a/tests/ProjectEuler.Benchmarks/PuzzleBenchmarks.cs
+++ b/tests/ProjectEuler.Benchmarks/PuzzleBenchmarks.cs
@@ -2,13 +2,11 @@
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnosers;
 using MartinCostello.ProjectEuler.Puzzles;
 
 namespace MartinCostello.ProjectEuler.Benchmarks;
 
-[EventPipeProfiler(EventPipeProfile.CpuSampling)]
-[MemoryDiagnoser]
+[Config(typeof(CustomBenchmarkConfig))]
 public class PuzzleBenchmarks
 {
     public static IEnumerable<object> Puzzles()


### PR DESCRIPTION
- Remove `--framework` argument.
- Disable `UseArtifactsOutput` for benchmarks.
- Fix no benchmarks being run.
