### PR TITLE
Remove redundant cast

### DIFF
--- a/src/ProjectEuler/Puzzles/Puzzle035.cs
+++ b/src/ProjectEuler/Puzzles/Puzzle035.cs
@@ -26,7 +26,7 @@ public sealed class Puzzle035 : Puzzle
         if (value < 12)
         {
             // The only rotation for values less than 12 is the value itself
-            return [(long)value];
+            return [value];
         }
 
         IReadOnlyList<int> digits = Maths.Digits(value);


### PR DESCRIPTION
Remove redundant cast identified by .NET 9 in #334.
