### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmark-crank.ps1
+++ b/benchmark-crank.ps1
@@ -58,3 +58,7 @@ try {
 finally {
     Stop-Process -InputObject $agent -Force | Out-Null
 }
+
+if ($LASTEXITCODE -ne 0) {
+    throw "crank-pr failed with exit code $LASTEXITCODE"
+}

--- a/crank.ps1
+++ b/crank.ps1
@@ -40,3 +40,7 @@ try {
 finally {
     Stop-Process -InputObject $agent -Force | Out-Null
 }
+
+if ($LASTEXITCODE -ne 0) {
+    throw "crank failed with exit code $LASTEXITCODE"
+}

--- a/crank.yml
+++ b/crank.yml
@@ -19,4 +19,10 @@ scenarios:
       job: microbenchmarks
 
 profiles:
-  local: {}
+  local:
+    variables:
+      serverAddress: localhost
+    jobs:
+      application:
+        endpoints:
+          - http://localhost:5010


### PR DESCRIPTION
- Fix incomplete crank profile causing `NullReferenceException`.
- Fail the workflow if crank fails.
