### PR TITLE
Add continuous benchmarks

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -1,0 +1,65 @@
+name: benchmark-ci
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  NUGET_XMLDOC_MODE: skip
+  TERM: xterm
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.gitattributes'
+      - '**/*.gitignore'
+      - '**/*.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+
+    - name: Run benchmarks
+      shell: pwsh
+      run: ./benchmark.ps1
+
+    - name: Publish results
+      uses: benchmark-action/github-action-benchmark@v1
+      with:
+        auto-push: true
+        alert-comment-cc-users: '@${{ github.repository_owner }}'
+        benchmark-data-dir-path: 'project-euler'
+        comment-on-alert: true
+        fail-on-alert: true
+        gh-pages-branch: main
+        gh-repository: 'github.com/${{ github.repository_owner }}/benchmarks'
+        github-token: ${{ secrets.BENCHMARKS_TOKEN }}
+        name: 'Project Euler'
+        output-file-path: BenchmarkDotNet.Artifacts/results/MartinCostello.ProjectEuler.Benchmarks.PuzzleBenchmarks-report-full-compressed.json
+        tool: 'benchmarkdotnet'
+
+    - name: Output summary
+      shell: pwsh
+      run: |
+        $repoName = ${env:GITHUB_REPOSITORY}.Split("/")[-1]
+        $summary = Get-Content -Path (Join-Path ${env:GITHUB_WORKSPACE} "BenchmarkDotNet.Artifacts" "results" "MartinCostello.ProjectEuler.Benchmarks.PuzzleBenchmarks-report-github.md") -Raw
+        $summary += "`n`n"
+        $summary += "View benchmark results history [here](https://benchmarks.martincostello.com/${repoName})."
+        $summary >> ${env:GITHUB_STEP_SUMMARY}

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Run benchmarks
       shell: pwsh
-      run: ./benchmark.ps1
+      run: ./benchmark.ps1 -Job Short
 
     - name: Publish results
       uses: benchmark-action/github-action-benchmark@v1

--- a/benchmark.ps1
+++ b/benchmark.ps1
@@ -89,4 +89,9 @@ if (![string]::IsNullOrEmpty($Job)) {
     $additionalArgs += $Job
 }
 
+if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
+    $additionalArgs += "--exporters"
+    $additionalArgs += "json"
+}
+
 & $dotnet run --project $benchmarks --configuration "Release" -- $additionalArgs


### PR DESCRIPTION
Add GitHub Actions workflow to run continuous benchmarks and publish to a tracking website.
