### PR TITLE
Remove BenchmarkDotNet.TestAdapter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,6 @@ updates:
 - package-ecosystem: nuget
   directory: "/"
   groups:
-    BenchmarkDotNet:
-      patterns:
-        - BenchmarkDotNet*
     xunit:
       patterns:
         - xunit*

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="BenchmarkDotNet.TestAdapter" Version="0.14.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="xunit" Version="2.9.0" />

--- a/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
+++ b/tests/ProjectEuler.Benchmarks/ProjectEuler.Benchmarks.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Benchmarks for ProjectEuler.</Description>
-    <GenerateProgramFile>false</GenerateProgramFile>
     <NoWarn>$(NoWarn);CA1034;CA1056;CA2007;SA1600</NoWarn>
     <OutputType>Exe</OutputType>
     <RootNamespace>MartinCostello.ProjectEuler.Benchmarks</RootNamespace>
@@ -13,7 +12,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
-    <PackageReference Include="BenchmarkDotNet.TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove BenchmarkDotNet.TestAdapter as it might be the source of the slow .NET Bumper runs for .NET 9 for this repo.
