### PR TITLE
Publish artifacts

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: ./benchmark.ps1 -Job Short
 
     - name: Publish BenchmarkDotNet artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:
         name: artifacts

--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -39,6 +39,14 @@ jobs:
       shell: pwsh
       run: ./benchmark.ps1 -Job Short
 
+    - name: Publish BenchmarkDotNet artifacts
+      uses: actions/upload-artifact@v3
+      if: ${{ !cancelled() }}
+      with:
+        name: artifacts
+        path: ./BenchmarkDotNet.Artifacts/results/*
+        if-no-files-found: error
+
     - name: Get repository name
       id: get-repo-name
       shell: pwsh


### PR DESCRIPTION
Publish the artifact results to the workflow from BenchmarkDotNet before it is processed and summarised.