### PR TITLE
Fix build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Project Euler
 
-[![Build status](https://github.com/martincostello/project-euler/workflows/build/badge.svg?branch=main&event=push)](https://github.com/martincostello/project-euler/actions?query=workflow%3Abuild+branch%3Amain+event%3Apush)
+[![Build status](https://github.com/martincostello/project-euler/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/martincostello/project-euler/actions/workflows/build.yml?query=branch%3Amain+event%3Apush)
 
 ## Overview
 


### PR DESCRIPTION
Fix-up the build badge as the old URL seems to have stopped working.