### PR TITLE
Add environment for secret usage

### DIFF
--- a/.github/workflows/benchmark-ci.yml
+++ b/.github/workflows/benchmark-ci.yml
@@ -24,7 +24,7 @@ permissions: {}
 jobs:
   benchmark:
     name: benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   benchmark:
     name: benchmark
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       github.event.repository.fork == false &&
       github.event.issue.pull_request != '' &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,12 @@ permissions: {}
 
 jobs:
   build:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os-name }}
+    runs-on: ${{ matrix.runner }}
+
+    environment:
+      name: build
+      deployment: false
 
     permissions:
       contents: read
@@ -27,7 +31,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        include:
+          - os-name: macos
+            # renovate: datasource=github-runners depType=github-runner
+            runner: macos-26
+          - os-name: linux
+            # renovate: datasource=github-runners depType=github-runner
+            runner: ubuntu-24.04
+          - os-name: windows
+            # renovate: datasource=github-runners depType=github-runner
+            runner: windows-2025
 
     steps:
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read
@@ -51,7 +51,7 @@ jobs:
   codeql:
     if: ${{ !cancelled() }}
     needs: [ analysis ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Report status

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       actions: read


### PR DESCRIPTION
- Add an environment to CI to guard access to `CRASH_DUMPS_STORAGE_CONNECTION_STRING`.
- Use specific GitHub Actions runner labels instead of "latest".
